### PR TITLE
[EN-1416] Add RPC services to Juwai-Mysql box

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,11 @@
 ---
+- name: supervisord update consul-alerts
+  command: supervisorctl update consul_alerts
+  notify: supervisord restart consul-alerts
+  when: consul_alerts_supervisor_enabled
+
 - name: supervisord restart consul-alerts
   supervisorctl:
-    name: 'consul_alerts:*'
+    name: 'consul_alerts:'
     state: restarted
   when: consul_alerts_supervisor_enabled
-  ignore_errors: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,4 +16,4 @@
     group: root
     mode: 0644
   when: consul_alerts_supervisor_enabled
-  notify: supervisord restart consul-alerts
+  notify: supervisord update consul-alerts


### PR DESCRIPTION
http://jira.juwai.com/browse/EN-1416

Calling update makes sure supervisord has read the config file. If trying to restart the daemon before reading the config file supervisord can shut down. I don't know why this happens. It's probably Ansible related and not supervisord's fault. Also, if config is not read, you can not start the daemon.

@imlazyone @agirivera please review
